### PR TITLE
Ensure welcome heading is one line

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -257,7 +257,7 @@ export function LandingPage({ onAccountCreated }: LandingPageProps) {
                 >
                   {/* Main Heading */}
                   <div className="space-y-6">
-                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight whitespace-nowrap">
+                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight whitespace-nowrap w-fit mx-auto">
                       Welcome to{' '}
                       <span 
                         className="font-medium inline-block"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -257,7 +257,7 @@ export function LandingPage({ onAccountCreated }: LandingPageProps) {
                 >
                   {/* Main Heading */}
                   <div className="space-y-6">
-                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight">
+                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight whitespace-nowrap">
                       Welcome to{' '}
                       <span 
                         className="font-medium inline-block"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -244,7 +244,7 @@ export function LandingPage({ onAccountCreated }: LandingPageProps) {
 
         {/* Main Content */}
         <div className="pt-16 flex-1 flex items-center justify-center">
-          <div className="max-w-lg w-full mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-4xl w-full mx-auto px-4 sm:px-6 lg:px-8">
             <AnimatePresence mode="wait">
               {!showLoginForm ? (
                 <motion.div
@@ -256,8 +256,8 @@ export function LandingPage({ onAccountCreated }: LandingPageProps) {
                   className="text-center space-y-12"
                 >
                   {/* Main Heading */}
-                  <div className="space-y-6">
-                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight whitespace-nowrap w-fit mx-auto">
+                  <div className="space-y-6 flex flex-col items-center">
+                    <h1 className="text-4xl sm:text-5xl md:text-6xl font-medium text-white leading-tight whitespace-nowrap text-center">
                       Welcome to{' '}
                       <span 
                         className="font-medium inline-block"


### PR DESCRIPTION
Add `whitespace-nowrap` to the main heading to prevent it from stacking.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb9948e0-0290-45c1-981a-01e8a4f51f1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb9948e0-0290-45c1-981a-01e8a4f51f1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

